### PR TITLE
feat: Added skip button functionality #3

### DIFF
--- a/src/components/Intro/Intro.styles.ts
+++ b/src/components/Intro/Intro.styles.ts
@@ -1,12 +1,12 @@
-import { styled } from 'styled-components';
+import { styled, keyframes } from 'styled-components';
 import { Button } from 'antd';
 import introBackground from '../../assets/introBackground.jpg';
 
 export const S = {
-  IntroWrapper: styled.h2`
+  IntroWrapper: styled.div`
     width: 100vw;
     height: 100vh;
-    font-size: 17px;
+    position: relative;
 
     background-image: linear-gradient(
         0deg,
@@ -35,5 +35,28 @@ export const S = {
 
   Button: styled(Button)`
     margin: 1rem;
+  `,
+
+  AllSkipButton: styled(Button)`
+    color: white;
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 1.5rem;
+
+    &:hover {
+      color: #ff5349 !important;
+      transition: color 0.3s ease-in-out;
+    }
+  `,
+
+  SkipButton: styled(Button)`
+    color: white;
+    margin: 1rem;
+
+    &:hover {
+      color: #ff5349 !important;
+      transition: color 0.3s ease-in-out;
+    }
   `,
 };

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -5,62 +5,21 @@ import { useNavigate } from 'react-router-dom';
 
 const Intro = () => {
   const navigate = useNavigate();
-  //
-  const [oneStep, setOneStep] = useState<boolean>(true);
-  const [twoStep, setTwoStep] = useState<boolean>(false);
-  const [threeStep, setThreeStep] = useState<boolean>(false);
-  const [fourStep, setFourStep] = useState<boolean>(false);
+
+  const [currentStep, setCurrentStep] = useState<number>(0);
+  const [enterButton, setEnterButton] = useState<boolean>(false);
+  const [skipToggler, setSkipToggler] = useState<boolean>(false);
+  const [lastSkipToggler, setLastSkipToggler] = useState<boolean>(true);
+  const handleSkipButtonClick = () => {
+    setCurrentStep(currentStep + 1);
+  };
 
   return (
     <S.IntroWrapper>
-      {oneStep && (
-        <TypeIt
-          options={{
-            speed: 100,
-            cursor: false,
-            afterComplete: async (instance: typeof TypeIt) => {
-              setTimeout(() => {
-                setOneStep(false);
-                setTwoStep(true);
-              }, 1500);
-            },
-          }}
-        >
-          <S.IntroText>
-            <p>언제나 같은 아침, 매일 똑같은 일상에 지쳐가던 어느 날,</p>
-            <p>눈을 떠보니 도시가 좀비 사태에 휩싸였어.</p>
-            <p>
-              그렇게 시작된 이상한 현실에 나도 모르게 긴장이 감돌기 시작했지.
-            </p>
-            <p>막연한 불안감이 나를 감싸기 시작했어...</p>
-          </S.IntroText>
-        </TypeIt>
-      )}
-      {twoStep && (
-        <TypeIt
-          options={{
-            speed: 100,
-            cursor: false,
-            afterComplete: async (instance: typeof TypeIt) => {
-              setTimeout(() => {
-                setTwoStep(false);
-                setThreeStep(true);
-              }, 1500);
-            },
-          }}
-        >
-          <S.IntroText>
-            <p>하지만 이제, 더 이상 도망치지 않아도 돼.</p>
-            <p>
-              세상은 한달에 1번씩 백신을 접종하지 않으면 좀비로 변해버리는 곳이
-              되었어.
-            </p>
-            <p>이제는 내가 내 삶을 쥐고 갈 차례야.</p>
-            <p>무서운 시간이지만, 동시에 내게 주어진 두 번째 기회야.</p>
-          </S.IntroText>
-        </TypeIt>
-      )}
-      {threeStep && (
+      <S.AllSkipButton type="text" onClick={() => navigate('/auth')}>
+        전체스킵 &gt;&gt;
+      </S.AllSkipButton>
+      {currentStep === 0 && (
         <>
           <TypeIt
             options={{
@@ -68,23 +27,102 @@ const Intro = () => {
               cursor: false,
               afterComplete: async (instance: typeof TypeIt) => {
                 setTimeout(() => {
-                  setFourStep(true);
-                }, 100);
+                  setCurrentStep(1);
+                }, 1500);
               },
             }}
           >
             <S.IntroText>
-              <p>100가지의 버킷리스트를 작성하고, 이를 하나씩 실천해야해.</p>
+              <p>언제나 같은 아침, 매일 똑같은 일상에 지쳐가던 어느 날,</p>
+              <p>눈을 떠보니 도시가 좀비 사태에 휩싸였어.</p>
               <p>
-                눈에 보이지 않는 위험한 적들과 맞서 싸우며, 내 삶을 다시
-                채워나가는 거야.
+                그렇게 시작된 이상한 현실에 나도 모르게 긴장이 감돌기 시작했지.
               </p>
-              <p>그럼 시작해보자!</p>
+              <p>막연한 불안감이 나를 감싸기 시작했어...</p>
             </S.IntroText>
           </TypeIt>
+          <S.SkipButton type="text" onClick={handleSkipButtonClick}>
+            스킵 &gt;&gt;
+          </S.SkipButton>
         </>
       )}
-      {fourStep && (
+      {currentStep === 1 && (
+        <>
+          <TypeIt
+            options={{
+              speed: 100,
+              cursor: false,
+              afterComplete: async (instance: typeof TypeIt) => {
+                setTimeout(() => {
+                  setCurrentStep(2);
+                }, 1500);
+              },
+            }}
+          >
+            <S.IntroText>
+              <p>하지만 이제, 더 이상 도망치지 않아도 돼.</p>
+              <p>
+                세상은 한달에 1번씩 백신을 접종하지 않으면 좀비로 변해버리는
+                곳이 되었어.
+              </p>
+              <p>이제는 내가 내 삶을 쥐고 갈 차례야.</p>
+              <p>무서운 시간이지만, 동시에 내게 주어진 두 번째 기회야.</p>
+            </S.IntroText>
+          </TypeIt>
+          <S.SkipButton type="text" onClick={handleSkipButtonClick}>
+            스킵 &gt;&gt;
+          </S.SkipButton>
+        </>
+      )}
+      {currentStep === 2 && (
+        <>
+          {skipToggler ? (
+            <>
+              <S.IntroText>
+                <p>100가지의 버킷리스트를 작성하고, 이를 하나씩 실천해야해.</p>
+                <p>
+                  눈에 보이지 않는 위험한 적들과 맞서 싸우며, 내 삶을 다시
+                  채워나가는 거야.
+                </p>
+                <p>그럼 시작해보자!</p>
+              </S.IntroText>
+              <S.Button onClick={() => navigate('/auth')}>입장하기</S.Button>
+            </>
+          ) : (
+            <>
+              <TypeIt
+                options={{
+                  speed: 100,
+                  cursor: false,
+                  afterComplete: async (instance: typeof TypeIt) => {
+                    // setTimeout(() => {
+                    setEnterButton(true);
+                    setLastSkipToggler(false);
+                    // }, 100);
+                  },
+                }}
+              >
+                <S.IntroText>
+                  <p>
+                    100가지의 버킷리스트를 작성하고, 이를 하나씩 실천해야해.
+                  </p>
+                  <p>
+                    눈에 보이지 않는 위험한 적들과 맞서 싸우며, 내 삶을 다시
+                    채워나가는 거야.
+                  </p>
+                  <p>그럼 시작해보자!</p>
+                </S.IntroText>
+              </TypeIt>
+              {lastSkipToggler && (
+                <S.SkipButton type="text" onClick={() => setSkipToggler(true)}>
+                  스킵 &gt;&gt;
+                </S.SkipButton>
+              )}
+            </>
+          )}
+        </>
+      )}
+      {enterButton && (
         <S.Button onClick={() => navigate('/auth')}>입장하기</S.Button>
       )}
     </S.IntroWrapper>


### PR DESCRIPTION
## 개요 🔎

인트로 스토리가 너무 길어 지루하지 않도록 스킵 버튼 기능을 추가하여 PR합니다.

## 작업사항 📝

- 전체 스킵 버튼 클릭 시 인트로 스토리를 모두 건너뛰고 로그인 화면으로 이동하는 기능 구현
- 스킵 버튼 클릭 시 인트로 스토리를 스킵하고 다음 단계로 이동하는 기능 구현
