### PR TITLE
20 feat style auth

### DIFF
--- a/src/components/Layout/Header.Styles.ts
+++ b/src/components/Layout/Header.Styles.ts
@@ -10,6 +10,9 @@ export const S = {
     color: var(--color-bg);
     font-weight: 600;
     align-items: center;
+    position: fixed;
+    width: 100%;
+    top: 0;
   `,
 
   UserDiv: styled.div`
@@ -19,12 +22,12 @@ export const S = {
   `,
 
   UserImage: styled.div`
-    background: #ffffff;
+    /* background: #ffffff; */
     height: 36px;
     width: 36px;
     border-radius: 50%;
     overflow: hidden;
-    background-color: black;
+    /* background-color: white; */
     cursor: pointer;
 
     img {
@@ -35,17 +38,19 @@ export const S = {
   `,
 
   LogOutButton: styled.button`
-    background-color: var(--color-primary);
-    border: none;
+    background-color: var(--color-accent);
+    border: 1px solid var(--color-white);
     padding: 8px;
     cursor: pointer;
-    color: var(--color-text);
+    color: var(--color-white);
     font-weight: 600;
     border-radius: 8px;
 
     &:hover {
-      background-color: var(--color-text);
-      color: var(--color-bg);
+      /* background-color: var(--color-text); */
+      background-color: var(--color-white);
+      color: var(--color-accent);
+      transition: 0.2s ease-out;
     }
   `,
 

--- a/src/components/Login/LoginForm.styles.ts
+++ b/src/components/Login/LoginForm.styles.ts
@@ -1,3 +1,116 @@
-const LoginFormStyle = () => {};
+import { Button, Input } from "antd";
+import { styled } from "styled-components";
 
-export default LoginFormStyle;
+export const S = {
+  LoginContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  `,
+
+  LoginTitle: styled.h2`
+      margin-bottom: 30px;
+  `,
+
+  WelcomeText: styled.p`
+    font-weight: bold;
+    font-size: 30px;
+  `,
+
+  WelcomeTextWrapper: styled.div`
+    /* background-color:blue; */
+    /* height: 10%; */
+    /* padding-top: 20px; */
+  `,
+
+  LoginForm: styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  min-width:  35vw;
+  height: 450px;
+  background-color: var(--color-bg);
+  border: 3px solid var(--color-accent);
+  border-radius: 10px;
+  padding: 20px 10px;
+  `,
+
+  LoginInputWrapper: styled.div`
+    /* background-color: aqua; */
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
+    height: 70%;
+    width: 100%;
+  `,
+
+  LoginInputInnerWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 70%;
+    height: 50%;
+  `,
+
+  LoginButtonAndErrorMessageWrapper: styled.div`
+    /* background-color: bisque; */
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  `,
+
+  Button: styled(Button)`
+  color: var(--color-text);
+  font-weight: 900;
+  height: 50px;
+  width: 70%;
+  
+
+  &:hover {
+    color: var(--color-accent) !important;
+    border-color: var(--color-accent) !important;
+  }
+
+  &:focus {
+      border-color: var(--color-accent) !important;
+      outline-color: var(--color-accent) !important;
+    }
+  `,
+
+  Input: styled(Input)`
+  width: 100%;
+  height: 50px;
+
+  &:hover {
+    border-color: var(--color-accent) !important;
+    outline-color: var(--color-accent) !important;
+  }
+
+  &:focus {
+      border-color: var(--color-accent) !important;
+      outline-color: var(--color-accent) !important;
+    }
+  `,
+
+  PasswordInput: styled(Input.Password)`
+  width: 100%;
+  height: 50px;
+
+  &:hover {
+    border-color: var(--color-accent) !important; 
+    outline-color: var(--color-accent) !important;
+  }
+  `,
+
+  ErrorMessage: styled.span`
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--color-accent);
+  margin-bottom: 10px;
+  `
+}

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import supabase from '../../api/supabase';
+import { S } from './LoginForm.styles';
 
 const LoginForm = () => {
   const [email, setEmail] = useState('');
@@ -76,31 +77,40 @@ const LoginForm = () => {
   };
 
   return (
-    <>
-      <div>좀비가 되기 전에 해야하는 100가지</div>
+    <S.LoginContainer>
+      <S.LoginTitle><img src='https://equsyyfbjtstiglyzukm.supabase.co/storage/v1/object/public/user-profile/logo/logo.png' alt='logo' width={'300px'}/></S.LoginTitle>
+      <S.LoginForm> 
+        <S.WelcomeTextWrapper>
+          <S.WelcomeText>welcome...☠</S.WelcomeText>
+        </S.WelcomeTextWrapper>
+        <S.LoginInputWrapper>
+          <S.LoginInputInnerWrapper>
+            <S.Input
+              type="email"
+              value={email}
+              onChange={onChange}
+              name="email"
+              placeholder="이메일"
+              autoFocus
+            />
+            <S.PasswordInput
+              type="password"
+              value={password}
+              onChange={onChange}
+              name="password"
+              placeholder="비밀번호"
+            />
+          </S.LoginInputInnerWrapper>
+        </S.LoginInputWrapper>
 
-      <form>
-        <input
-          type="email"
-          value={email}
-          onChange={onChange}
-          name="email"
-          placeholder="이메일"
-        />
-        <input
-          type="password"
-          value={password}
-          onChange={onChange}
-          name="password"
-          placeholder="비밀번호"
-        />
-        <button type="submit" onClick={handleLoginButtonClick}>
-          로그인
-        </button>
-        <br />
-      </form>
-      <span>{errorMessage}</span>
-    </>
+        <S.LoginButtonAndErrorMessageWrapper>
+          <S.ErrorMessage>{errorMessage}</S.ErrorMessage>
+          <S.Button onClick={handleLoginButtonClick}>
+            로그인
+          </S.Button>
+        </S.LoginButtonAndErrorMessageWrapper>
+      </S.LoginForm>
+    </S.LoginContainer>
   );
 };
 

--- a/src/components/MyPage/UserBucketByStatus.styles.ts
+++ b/src/components/MyPage/UserBucketByStatus.styles.ts
@@ -34,6 +34,7 @@ export const S = {
   BucketTotalCountNumber: styled.span`
     font-size: 50px;
     color: var(--color-text);
+    margin-right: 5px;
   `,
 
   BucketStatusListBox: styled.div`
@@ -66,7 +67,7 @@ export const S = {
 
   BucketStatusListCountNumber: styled.span`
     font-size: 40px;
-    margin-left: 5px;
+    margin-right: 5px;
     color: var(--color-text);
   `,
 };

--- a/src/components/MyPage/UserInfo.tsx
+++ b/src/components/MyPage/UserInfo.tsx
@@ -64,6 +64,7 @@ const UserInfo = ({ user }: { user: User | null }) => {
       try {
         const { error } = await supabaseService.auth.admin.deleteUser(UserUID);
         await supabase.from('users').delete().eq('email', user?.email);
+        await supabase.from('ducketList').delete().eq('email', user?.email);
         localStorage.removeItem('token');
         deleteProfileImage();
 

--- a/src/components/Signup/SignupForm.styles.ts
+++ b/src/components/Signup/SignupForm.styles.ts
@@ -1,3 +1,68 @@
-const SignupFormStyle = () => {};
+import styled from 'styled-components';
 
-export default SignupFormStyle;
+export const S = {
+  SignUpContainer: styled.div`
+    /* width: 100vw;
+    height: 100vh; */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  `,
+
+  SignUpTitle: styled.h2`
+    font-weight: bold;
+    font-size: 40px;
+    margin-bottom: 50px;
+  `,
+
+  SignUpForm: styled.form`
+    display: flex;
+    flex-direction: column;
+    width: 60vw;
+    background-color: var(--color-primary);
+    border-radius: 10px;
+    padding: 20px 10px;
+  `,
+
+  SignUpImageInputWrapper: styled.div`
+    display: flex;
+    width: 100%;
+    justify-content: space-around;
+  `,
+
+  SignUpImageContentWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    display: flex;
+    align-items: center;
+  `,
+
+  SignUpInputWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  `,
+
+  SignUpImageBox: styled.div`
+    width: 300px;
+    height: 300px;
+    border-radius: 50%;
+    background-color:black;
+    overflow: hidden;
+
+    img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
+  `,
+
+  SignUpImageText: styled.label`
+    margin: 10px 0;
+    font-weight: bold;
+    color: var(--color-accent)
+  `
+
+
+}

--- a/src/components/Signup/SignupForm.styles.ts
+++ b/src/components/Signup/SignupForm.styles.ts
@@ -19,7 +19,9 @@ export const S = {
   SignUpForm: styled.form`
     display: flex;
     flex-direction: column;
-    width: 60vw;
+    justify-content: space-around;
+    width: 50vw;
+    height: 450px;
     background-color: var(--color-primary);
     border-radius: 10px;
     padding: 20px 10px;
@@ -50,6 +52,7 @@ export const S = {
     border-radius: 50%;
     background-color:black;
     overflow: hidden;
+    margin: 10px 0;
 
     img {
       object-fit: cover;

--- a/src/components/Signup/SignupForm.styles.ts
+++ b/src/components/Signup/SignupForm.styles.ts
@@ -1,3 +1,4 @@
+import { Button, Input } from 'antd';
 import styled from 'styled-components';
 
 export const S = {
@@ -11,26 +12,27 @@ export const S = {
   `,
 
   SignUpTitle: styled.h2`
-    font-weight: bold;
-    font-size: 40px;
-    margin-bottom: 50px;
+    margin-bottom: 30px;
   `,
 
   SignUpForm: styled.form`
     display: flex;
     flex-direction: column;
     justify-content: space-around;
-    width: 50vw;
+    align-items: center;
+    min-width: 50vw;
     height: 450px;
-    background-color: var(--color-primary);
+    background-color: var(--color-bg);
+    border: 3px solid var(--color-accent);
     border-radius: 10px;
     padding: 20px 10px;
   `,
 
   SignUpImageInputWrapper: styled.div`
     display: flex;
-    width: 100%;
+    min-width: 100%;
     justify-content: space-around;
+    align-items: center;
   `,
 
   SignUpImageContentWrapper: styled.div`
@@ -38,19 +40,22 @@ export const S = {
     flex-direction: column;
     display: flex;
     align-items: center;
+    min-width: 50%;
   `,
 
   SignUpInputWrapper: styled.div`
+    height: 90%;
+    min-width: 50%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: space-around;
+    margin-left: 15px;
   `,
 
   SignUpImageBox: styled.div`
-    width: 300px;
-    height: 300px;
+    width: 250px;
+    height: 250px;
     border-radius: 50%;
-    background-color:black;
     overflow: hidden;
     margin: 10px 0;
 
@@ -63,9 +68,59 @@ export const S = {
 
   SignUpImageText: styled.label`
     margin: 10px 0;
+    /* font-weight: bold; */
+    color: var(--color-accent);
+    cursor: pointer;
+  `,
+
+  Input: styled(Input)`
+    max-width: 350px;
+    min-width: 300px;
+    height: 50px;
+
+    &:hover {
+      border-color: var(--color-accent) !important;
+      outline-color: var(--color-accent) !important;
+    }
+
+    &:focus {
+      border-color: var(--color-accent) !important;
+      outline-color: var(--color-accent) !important;
+    }
+  `,
+
+  PasswordInput: styled(Input.Password)`
+    max-width: 350px;
+    min-width: 300px;
+    height: 50px;
+
+    &:hover {
+      border-color: var(--color-accent) !important; 
+      outline-color: var(--color-accent) !important;
+    }
+
+     &:focus {
+      border-color: var(--color-accent) !important;
+      outline-color: var(--color-accent) !important;
+    }
+  `,
+
+  Button: styled(Button)`
+  /* background-color: var(--color-primary); */
+  color: var(--color-text);
+  font-weight: 900;
+  height: 50px;
+  width: 84%;
+
+  &:hover {
+    color: var(--color-accent) !important;
+    border-color: var(--color-accent) !important;
+  }
+  `,
+
+  ErrorMessage: styled.span`
+    font-size: 14px;
     font-weight: bold;
     color: var(--color-accent);
   `
-
-
 }

--- a/src/components/Signup/SignupForm.styles.ts
+++ b/src/components/Signup/SignupForm.styles.ts
@@ -64,7 +64,7 @@ export const S = {
   SignUpImageText: styled.label`
     margin: 10px 0;
     font-weight: bold;
-    color: var(--color-accent)
+    color: var(--color-accent);
   `
 
 

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -26,7 +26,7 @@ const SignupForm= () => {
   // default image url을 storage에서 가져오기
   const { data } = supabaseService.storage
     .from('user-profile')
-    .getPublicUrl('pms.jpg');
+    .getPublicUrl('default-profile-image.png');
   const defaultImageUrl = data.publicUrl;
   console.log('defaultImageUrl : ', defaultImageUrl);
 
@@ -200,8 +200,7 @@ const SignupForm= () => {
 
   return (
     <S.SignUpContainer>
-      <S.SignUpTitle>좀비가 되기 전에 해야하는 100가지</S.SignUpTitle>
-
+      <S.SignUpTitle><img src='https://equsyyfbjtstiglyzukm.supabase.co/storage/v1/object/public/user-profile/logo/logo.png' alt='logo' width={'300px'}/></S.SignUpTitle>
       <S.SignUpForm>
         <S.SignUpImageInputWrapper>
           <S.SignUpImageContentWrapper>
@@ -226,43 +225,48 @@ const SignupForm= () => {
           </S.SignUpImageContentWrapper>
           
             <S.SignUpInputWrapper>
-              <input
+              <S.Input
+                showCount
+                maxLength={10}
                 type="nickname"
                 value={nickname}
                 onChange={onChange}
                 name="nickname"
                 placeholder="닉네임"
+                id='nickname'
+                autoFocus
               />
-              <input
+              <S.Input
                 type="email"
                 value={email}
                 onChange={onChange}
                 name="email"
                 placeholder="이메일"
+                id='email'
               />
-              <input
+              <S.PasswordInput
                 type="password"
                 value={password}
                 onChange={onChange}
                 name="password"
                 placeholder="비밀번호"
               />
-              <input
+              <S.PasswordInput
                 type="password"
                 value={checkPassword}
                 onChange={onChange}
                 name="checkPassword"
-                placeholder="비밀번호 체크"
+                placeholder="비밀번호 확인"
               />
             </S.SignUpInputWrapper>
           </S.SignUpImageInputWrapper>
         <div>
         </div>
-        <button type="submit" onClick={handleSignUpButtonClick}>
+        <S.ErrorMessage>{errorMessage}</S.ErrorMessage>
+        <S.Button onClick={handleSignUpButtonClick}>
           회원가입
-        </button>
+        </S.Button>
       </S.SignUpForm>
-      <span>{errorMessage}</span>
     </S.SignUpContainer>
   );
 };

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -3,8 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import supabase from '../../api/supabase';
 import supabaseService from '../../api/supabaseService';
 import { S } from './SignupForm.styles';
+import { Input } from 'antd';
 
-const SignupForm = () => {
+const SignupForm= () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [checkPassword, setCheckPassword] = useState('');

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import supabase from '../../api/supabase';
 import supabaseService from '../../api/supabaseService';
+import { S } from './SignupForm.styles';
 
 const SignupForm = () => {
   const [email, setEmail] = useState('');
@@ -197,62 +198,71 @@ const SignupForm = () => {
   };
 
   return (
-    <>
-      <div>좀비가 되기 전에 해야하는 100가지</div>
+    <S.SignUpContainer>
+      <S.SignUpTitle>좀비가 되기 전에 해야하는 100가지</S.SignUpTitle>
 
-      <form>
+      <S.SignUpForm>
+        <S.SignUpImageInputWrapper>
+          <S.SignUpImageContentWrapper>
+            <S.SignUpImageBox>
+                {newProfileImageURL ? (
+                  <img src={newProfileImageURL as string} alt="new-priview-img" />
+                ) : defaultProfileImageURL ? (
+                  <img src={defaultProfileImageURL} alt="default=priview-img" />
+                ) : (
+                  <span>이미지 미리보기</span>
+                )}
+            </S.SignUpImageBox>
+            <S.SignUpImageText htmlFor="profileImg">프로필 이미지 등록</S.SignUpImageText>
+            <input
+              type="file"
+              accept="image/*"
+              id="profileImg"
+              style={{ display: 'none' }}
+              onChange={changhProfileImageFile}
+              ref={imageRef}
+            />
+          </S.SignUpImageContentWrapper>
+          
+            <S.SignUpInputWrapper>
+              <input
+                type="nickname"
+                value={nickname}
+                onChange={onChange}
+                name="nickname"
+                placeholder="닉네임"
+              />
+              <input
+                type="email"
+                value={email}
+                onChange={onChange}
+                name="email"
+                placeholder="이메일"
+              />
+              <input
+                type="password"
+                value={password}
+                onChange={onChange}
+                name="password"
+                placeholder="비밀번호"
+              />
+              <input
+                type="password"
+                value={checkPassword}
+                onChange={onChange}
+                name="checkPassword"
+                placeholder="비밀번호 체크"
+              />
+            </S.SignUpInputWrapper>
+          </S.SignUpImageInputWrapper>
         <div>
-          {newProfileImageURL ? (
-            <img src={newProfileImageURL as string} alt="new-priview-img" />
-          ) : defaultProfileImageURL ? (
-            <img src={defaultProfileImageURL} alt="default=priview-img" />
-          ) : (
-            <span>이미지 미리보기</span>
-          )}
-          <label htmlFor="profileImg">프로필 이미지 등록</label>
-          <input
-            type="file"
-            accept="image/*"
-            id="profileImg"
-            style={{ display: 'none' }}
-            onChange={changhProfileImageFile}
-            ref={imageRef}
-          />
         </div>
-        <input
-          type="nickname"
-          value={nickname}
-          onChange={onChange}
-          name="nickname"
-          placeholder="닉네임"
-        />
-        <input
-          type="email"
-          value={email}
-          onChange={onChange}
-          name="email"
-          placeholder="이메일"
-        />
-        <input
-          type="password"
-          value={password}
-          onChange={onChange}
-          name="password"
-          placeholder="비밀번호"
-        />
-        <input
-          type="password"
-          value={checkPassword}
-          onChange={onChange}
-          name="checkPassword"
-          placeholder="비밀번호 체크"
-        />
         <button type="submit" onClick={handleSignUpButtonClick}>
           회원가입
         </button>
-      </form>
+      </S.SignUpForm>
       <span>{errorMessage}</span>
-    </>
+    </S.SignUpContainer>
   );
 };
 

--- a/src/pages/Auth.styles.ts
+++ b/src/pages/Auth.styles.ts
@@ -1,3 +1,4 @@
+import { Button } from 'antd';
 import styled from 'styled-components';
 
 export const S = {
@@ -9,13 +10,47 @@ export const S = {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    position: relative;
   `,
 
-  AuthContentBox: styled.div`
+  AuthCheckUserContentBox: styled.div`
     display: flex;
-    width: 230px;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     margin-top: 30px;
+    min-width: 200px;
+  `,
+
+  AuthCheckUserText: styled.span`
+    color: var(--color-white);
+  `,
+
+  Button: styled(Button)`
+  background-color: rgba(255,255,255, 0.8);
+  color: var(--color-text);
+  font-weight: 900;
+  margin-left: 20px;
+  
+
+  &:hover {
+    color: var(--color-accent) !important;
+    border-color: var(--color-accent) !important;
+  }
+  `,
+  
+  RedBox: styled.div`
+    width: 100vw;
+    height: 50vh;
+    background-color: var(--color-accent);
+    position: absolute;
+    bottom: 0;
+  `,
+
+  AbsoluteBox: styled.div`
+    position: absolute;
+    z-index: 1;
+    top: 47%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   `
 }

--- a/src/pages/Auth.styles.ts
+++ b/src/pages/Auth.styles.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const S = {
+  AuthContainer: styled.div`
+    width: 100vw;
+    height: 100vh;
+    background-color: var(--color-bg);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  `,
+
+  AuthContentBox: styled.div`
+    display: flex;
+    width: 230px;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 30px;
+  `
+}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import LoginForm from '../components/Login/LoginForm';
 import SignupForm from '../components/Signup/SignupForm';
 import supabase from '../api/supabase';
+import { S } from './Auth.styles';
 
 type Props = {};
 
@@ -19,12 +20,14 @@ const Auth = (props: Props) => {
   }
   currentUser();
 
-  return (<>
+  return (<S.AuthContainer>
   {isLogin? <LoginForm /> : <SignupForm/>}
+  <S.AuthContentBox>
   <span>{isLogin? "아직 회원이 아니신가요?" : "이미 회원이신가요?"}</span>
   <button onClick={handleToggleAuth}>{isLogin ? "회원가입" : "로그인"}</button>
+  </S.AuthContentBox>
 
-  </>);
+  </S.AuthContainer>);
 };
 
 export default Auth;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -20,14 +20,20 @@ const Auth = (props: Props) => {
   }
   currentUser();
 
-  return (<S.AuthContainer>
-  {isLogin? <LoginForm /> : <SignupForm/>}
-  <S.AuthContentBox>
-  <span>{isLogin? "아직 회원이 아니신가요?" : "이미 회원이신가요?"}</span>
-  <button onClick={handleToggleAuth}>{isLogin ? "회원가입" : "로그인"}</button>
-  </S.AuthContentBox>
-
-  </S.AuthContainer>);
+  return (
+  <>
+    <S.AuthContainer>
+      <S.AbsoluteBox>
+        {isLogin? <LoginForm /> : <SignupForm/>}
+        <S.AuthCheckUserContentBox>
+          <S.AuthCheckUserText>{isLogin? "회원이 아니신가요?" : "회원이신가요?"}</S.AuthCheckUserText>
+          <S.Button onClick={handleToggleAuth}>{isLogin ? "회원가입" : "로그인"}</S.Button>
+        </S.AuthCheckUserContentBox>
+      </S.AbsoluteBox>
+      <S.RedBox></S.RedBox>
+    </S.AuthContainer>
+  </>
+  );
 };
 
 export default Auth;

--- a/src/pages/BucketList.tsx
+++ b/src/pages/BucketList.tsx
@@ -64,6 +64,7 @@ export default BucketList;
 const Main = styled.main`
   background-color: #f8f8f8;
   min-height: 100vh;
+  padding-top: 60px;
 `;
 
 const S = {

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -23,6 +23,7 @@ const GlobalStyle = createGlobalStyle`
 
   body {
     background-color: var(--color-bg);
+    color: var(--color-text);
     /* font-family: 'CookieRun-Regular'; */
   }
 `;


### PR DESCRIPTION
## 개요 🔎

Auth 관련 페이지 css 추가 후 팀원들과 코드 합치기

## 작업사항 📝

1. Auth 페이지 css
2. login component css
3. signup component css
4. header css - (1) fixed로 띄우기 (2) 로그아웃 버튼 디자인 수정 (3) width: 100wv → 100% (로그아웃 btn이 오른쪽에 붙어버리기 때문에 해결)
5. BucketList css - 4번에서 header를 fixed로 변경하면서 Bucketlist가 겹쳐지는 현상 - 일단 S.Main에 padding-top: 60px;으로 해결 